### PR TITLE
feat: add AI provider switching (codex/claude)

### DIFF
--- a/.ralph/README.md
+++ b/.ralph/README.md
@@ -5,27 +5,60 @@ Autonomous AI development loops for the shadr project.
 ## Quick Start
 
 ```bash
-# 1. Plan - analyze codebase, generate tasks
+# 1. Set your provider in config.sh (default: codex)
+# Or use --provider flag
+
+# 2. Plan - analyze codebase, generate tasks
 .ralph/ralph-plan.sh
 
-# 2. Review fix_plan.md
+# 3. Review fix_plan.md
 
-# 3. Build - run development loop
-.ralph/ralph.sh --max 20    # Recommended: set iteration limit
+# 4. Build - run development loop
+.ralph/ralph.sh --max 20
+```
+
+## AI Providers
+
+Ralph supports switching between AI providers:
+
+| Provider | CLI | Env Variable |
+|----------|-----|--------------|
+| `codex` | [OpenAI Codex](https://github.com/openai/codex) | `OPENAI_API_KEY` |
+| `claude` | [Claude Code](https://github.com/anthropics/claude-code) | `ANTHROPIC_API_KEY` |
+
+### Switch Provider
+
+```bash
+# Option 1: Edit config.sh (persistent)
+# Set PROVIDER="codex" or PROVIDER="claude"
+
+# Option 2: Command line (one-time)
+.ralph/ralph.sh --provider claude --max 20
+.ralph/ralph-plan.sh --provider codex
+```
+
+### Install CLIs
+
+```bash
+# OpenAI Codex
+npm install -g @openai/codex
+
+# Claude Code
+npm install -g @anthropic-ai/claude-code
 ```
 
 ## How It Works
 
 ```
 while true; do
-    cat PROMPT.md | claude --dangerously-skip-permissions
+    cat PROMPT.md | <provider-cli>
 done
 ```
 
 Each iteration:
 1. Reads prompt + project files
 2. Picks ONE task from `fix_plan.md`
-3. Searches codebase before changing (critical!)
+3. Searches codebase before changing
 4. Implements the task
 5. Runs validation
 6. Updates docs and commits
@@ -39,16 +72,18 @@ Progress persists in **files and git**, not LLM context.
 |--------|---------|
 | `ralph.sh` | Main development loop |
 | `ralph-plan.sh` | One-shot planning analysis |
+| `config.sh` | Default settings (provider, timeouts) |
 
 ### ralph.sh Options
 
 ```bash
 .ralph/ralph.sh [options]
 
-  -p, --prompt FILE    Prompt file (default: PROMPT.md)
-  --max N              Max iterations (default: unlimited)
-  --timeout N          Timeout per iteration in minutes (default: 60)
-  --no-change N        Stop after N iterations with no changes (default: 3)
+  --provider NAME    AI provider: claude, codex (default: from config.sh)
+  -p, --prompt FILE  Prompt file (default: PROMPT.md)
+  --max N            Max iterations (default: unlimited)
+  --timeout N        Timeout per iteration in minutes (default: 60)
+  --no-change N      Stop after N iterations with no changes (default: 3)
 ```
 
 ## Key Files
@@ -62,34 +97,13 @@ Progress persists in **files and git**, not LLM context.
 ## Best Practices
 
 1. **Always set --max**: `.ralph/ralph.sh --max 20` prevents runaway loops
-
 2. **One task per iteration**: Prompts enforce single-task focus
-
 3. **Search before assuming**: Critical to avoid duplicate implementations
-
 4. **Tune with guardrails**: When Ralph fails repeatedly, add "signs" to `AGENT.md`
-
 5. **Keep docs updated**: Ralph updates `fix_plan.md`, `AGENT.md`, and `specs/architecture.md`
-
-## When Things Go Wrong
-
-**Stagnation (no changes)**:
-- Check `fix_plan.md` - are tasks clear and actionable?
-- Check `AGENT.md` Learnings - is there a blocker documented?
-- Consider: `git reset --hard` and restart with clearer tasks
-
-**Wrong implementation**:
-- Add guardrail to `AGENT.md`
-- Update specs if requirements unclear
-- Re-run planning: `.ralph/ralph-plan.sh`
-
-**Costs too high**:
-- Use `--max` to limit iterations
-- Use `--timeout` to limit time per iteration
-- Run planning separately to validate tasks before building
 
 ## Resources
 
+- [OpenAI Codex CLI](https://github.com/openai/codex)
+- [Claude Code](https://github.com/anthropics/claude-code)
 - [Geoffrey Huntley's Guide](https://github.com/ghuntley/how-to-ralph-wiggum)
-- [Official Plugin](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
-- [frankbria/ralph-claude-code](https://github.com/frankbria/ralph-claude-code)

--- a/.ralph/config.sh
+++ b/.ralph/config.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
-# Ralph config - source this in custom scripts if needed
-MAX_NO_CHANGE=3
-BUILD_CMD="pnpm typecheck && pnpm check"
+# Ralph Wiggum Configuration
+# ==========================
+# Edit this file to set defaults for your project.
+
+# AI Provider: "claude" or "codex"
+# Override with: .ralph/ralph.sh --provider codex
+PROVIDER="codex"
+
+# Default prompt file
+# PROMPT_FILE="PROMPT.md"
+
+# Max iterations (0 = unlimited)
+# MAX_ITERATIONS=0
+
+# Timeout per iteration in minutes
+# TIMEOUT_MINS=60
+
+# Stop after N iterations with no git changes
+# MAX_NO_CHANGE=3

--- a/.ralph/ralph-plan.sh
+++ b/.ralph/ralph-plan.sh
@@ -3,9 +3,33 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "${SCRIPT_DIR}/.."
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-echo "Running planning analysis..."
-cat "${SCRIPT_DIR}/PROMPT_PLAN.md" | claude --dangerously-skip-permissions
+# Load config
+[[ -f "${SCRIPT_DIR}/config.sh" ]] && source "${SCRIPT_DIR}/config.sh"
+PROVIDER="${PROVIDER:-claude}"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --provider) PROVIDER="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: $0 [--provider claude|codex]"
+            exit 0 ;;
+        *) shift ;;
+    esac
+done
+
+cd "${PROJECT_ROOT}"
+
+# Build command
+case "${PROVIDER}" in
+    claude) AI_CMD="claude --dangerously-skip-permissions" ;;
+    codex)  AI_CMD="codex --full-auto" ;;
+    *) echo "Unknown provider: ${PROVIDER}"; exit 1 ;;
+esac
+
+echo "Running planning analysis with ${PROVIDER}..."
+cat "${SCRIPT_DIR}/PROMPT_PLAN.md" | ${AI_CMD}
 echo ""
 echo "Done. Review fix_plan.md then run: .ralph/ralph.sh"


### PR DESCRIPTION
Support switching between OpenAI Codex and Claude Code as the AI provider for Ralph loops.

Changes:
- ralph.sh: Add --provider flag (claude|codex)
- ralph-plan.sh: Add --provider flag
- config.sh: Add PROVIDER setting (default: codex)
- README.md: Document provider switching and installation

Usage:
  # Set default in config.sh PROVIDER="codex"

  # Or override per-command .ralph/ralph.sh --provider claude --max 20

Providers:
- codex: Uses `codex --full-auto` (requires OPENAI_API_KEY)
- claude: Uses `claude --dangerously-skip-permissions` (requires ANTHROPIC_API_KEY)